### PR TITLE
Refactored code to be more idiomatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ ios/Flutter/Generated.xcconfig
 ios/Runner/GeneratedPluginRegistrant.*
 .idea/
 smooth_star_rating.zip
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,56 +1,57 @@
+A star rating with touch and swipe rate enabled.
 
-A Star rating with touch and swipe rate enabled
-* Supports half rate and full rate (1.0 or 0.5)
+* Supports half rate (with half-filled stars) and full rate (only full stars)
 * Swipe for incrementing/decrementing rate amount
 * Change star body and boundary colors independently
 * Control size of the star rating
 * Set your desired total Star count
 * Supports click-to-rate
+
 ## Getting Started
 
-In your flutter project add the dependency:
+Add the dependency in your Flutter project:
 ```
-    dependencies:
-        ...
-        smooth_star_rating: 1.0.2
+dependencies:
+  ...
+  smooth_star_rating: 1.0.2
 ```
 
 ## Usage example
-``` 
+```
 import 'package:smooth_star_rating/smooth_star_rating.dart'; 
-``` 
+```
 
-```java 
+This widget doesn't take care of the state itself, so you'll need to store the
+rating for it (just like how `Checkbox`es work).
+
+In your state, simply add
+
+```dart
+double rating = 0;
+```
+
+and in your `build` method, you'll be able to use the widget like this:
+
+```dart
 SmoothStarRating(
-          allowHalfRating: false,
-          onRatingChanged: (v) {
-            rating = v;
-            setState(() {});
-          },
-          starCount: 5,
-          rating: rating,
-          size: 40.0,
-          color: Colors.green,
-          borderColor: Colors.green,
-        )
+  allowHalfRating: false,
+  onRatingChanged: (v) {
+    setState(() {
+      rating = v;
+    });
+  },
+  starCount: 5,
+  rating: rating,
+  size: 40,
+  color: Colors.green,
+  borderColor: Colors.green,
+)
 ```
 
-## Constructor parameters
-``` 
-allowHalfRating                 -   Whether to use whole number for rating(1.0  or 0.5)
-onRatingChanged(int rating)     -   Rating changed callback
-starCount                       -   The maximum amount of stars
-rating                          -   The current value of rating
-size                            -   The size of a single star
-color                           -   The body color of star
-borderColor                     -   The border color of star
-```
+## Screenshots
 
-### Screenshots
-
-#### Full Rating
+### Full Rating
 ![alt text](https://raw.githubusercontent.com/thangmam/smoothratingbar/master/screenshots/fullrating.gif "Full rating")
 
-#### Half Rating
-
+### Half Rating
 ![alt text](https://raw.githubusercontent.com/thangmam/smoothratingbar/master/screenshots/halfrating.gif  "Half Rating")

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,22 +15,21 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Rating bar demo',
-      theme: ThemeData(
-        primarySwatch: Colors.green,
-      ),
+      theme: ThemeData(primarySwatch: Colors.green),
       debugShowCheckedModeBanner: false,
       home: Scaffold(
         body: Center(
-            child: SmoothStarRating(
-          rating: rating,
-          size: 45,
-          starCount: 5,
-          onRatingChanged: (value) {
-            setState(() {
-              rating = value;
-            });
-          },
-        )),
+          child: SmoothStarRating(
+            rating: rating,
+            size: 45,
+            starCount: 5,
+            onRatingChanged: (value) {
+              setState(() {
+                rating = value;
+              });
+            },
+          ),
+        ),
       ),
     );
   }

--- a/lib/smooth_star_rating.dart
+++ b/lib/smooth_star_rating.dart
@@ -1,82 +1,74 @@
 library smooth_star_rating;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/material.dart';
-
-typedef void RatingChangeCallback(double rating);
 
 class SmoothStarRating extends StatelessWidget {
+  SmoothStarRating({
+    this.starCount = 5,
+    this.rating = 0.0,
+    this.onRatingChanged,
+    this.color,
+    this.borderColor,
+    this.size,
+    this.allowHalfRating = true,
+  })  : assert(starCount != null),
+        assert(rating != null),
+        assert(allowHalfRating != null);
+
   final int starCount;
   final double rating;
-  final RatingChangeCallback onRatingChanged;
+  final void Function(double rating) onRatingChanged;
   final Color color;
   final Color borderColor;
   final double size;
   final bool allowHalfRating;
 
-  SmoothStarRating(
-      {this.starCount = 5,
-      this.rating = 0.0,
-      this.onRatingChanged,
-      this.color,
-      this.borderColor,
-      this.size,
-      this.allowHalfRating = true}) {
-    assert(this.rating != null);
-  }
-
-  Widget buildStar(BuildContext context, int index) {
-    Icon icon;
-    if (index >= rating) {
-      icon = new Icon(
-        Icons.star_border,
-        color: borderColor ?? Theme.of(context).primaryColor,
-        size: size ?? 25.0,
-      );
-    } else if (index > rating - (allowHalfRating ? 0.5 : 1.0) &&
-        index < rating) {
-      icon = new Icon(
-        Icons.star_half,
-        color: color ?? Theme.of(context).primaryColor,
-        size: size ?? 25.0,
-      );
-    } else {
-      icon = new Icon(
-        Icons.star,
-        color: color ?? Theme.of(context).primaryColor,
-        size: size ?? 25.0,
-      );
-    }
-
-    return new GestureDetector(
-      onTap: () {
-        if (this.onRatingChanged != null) onRatingChanged(index + 1.0);
-      },
-      onHorizontalDragUpdate: (dragDetails) {
-        RenderBox box = context.findRenderObject();
-        var _pos = box.globalToLocal(dragDetails.globalPosition);
-        var i = _pos.dx / size;
-        var newRating = allowHalfRating ? i : i.round().toDouble();
-        if (newRating > starCount) {
-          newRating = starCount.toDouble();
-        }
-        if (newRating < 0) {
-          newRating = 0.0;
-        }
-        if (this.onRatingChanged != null) onRatingChanged(newRating);
-      },
-      child: icon,
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: Wrap(
+        alignment: WrapAlignment.start,
+        children: List.generate(starCount, (i) => _buildStar(context, i)),
+      ),
     );
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return new Material(
-      color: Colors.transparent,
-      child: new Wrap(
-          alignment: WrapAlignment.start,
-          children: new List.generate(
-              starCount, (index) => buildStar(context, index))),
+  Widget _buildStar(BuildContext context, int index) {
+    Icon icon;
+    if (index >= rating) {
+      icon = Icon(
+        Icons.star_border,
+        color: borderColor ?? Theme.of(context).primaryColor,
+        size: size ?? 25,
+      );
+    } else if (allowHalfRating && index > rating - 1) {
+      icon = Icon(
+        Icons.star_half,
+        color: color ?? Theme.of(context).primaryColor,
+        size: size ?? 25,
+      );
+    } else {
+      icon = Icon(
+        Icons.star,
+        color: color ?? Theme.of(context).primaryColor,
+        size: size ?? 25,
+      );
+    }
+
+    var ratingChangedCallback = onRatingChanged ?? (_) {};
+
+    return GestureDetector(
+      onTap: () => ratingChangedCallback(index + 1.0),
+      onHorizontalDragUpdate: (dragDetails) {
+        RenderBox box = context.findRenderObject();
+        var pos = box.globalToLocal(dragDetails.globalPosition);
+        var i = pos.dx / size;
+        var newRating =
+            (allowHalfRating ? i : i.roundToDouble()).clamp(0, starCount);
+        ratingChangedCallback(newRating);
+      },
+      child: icon,
     );
   }
 }

--- a/lib/smooth_star_rating.dart
+++ b/lib/smooth_star_rating.dart
@@ -64,8 +64,8 @@ class SmoothStarRating extends StatelessWidget {
         RenderBox box = context.findRenderObject();
         var pos = box.globalToLocal(dragDetails.globalPosition);
         var i = pos.dx / size;
-        var newRating =
-            (allowHalfRating ? i : i.roundToDouble()).clamp(0, starCount);
+        var newRating = (allowHalfRating ? i : i.roundToDouble())
+            .clamp(0.0, starCount.toDouble());
         ratingChangedCallback(newRating);
       },
       child: icon,

--- a/lib/smooth_star_rating.dart
+++ b/lib/smooth_star_rating.dart
@@ -15,12 +15,48 @@ class SmoothStarRating extends StatelessWidget {
         assert(rating != null),
         assert(allowHalfRating != null);
 
+  /// The maximum amount of stars.
   final int starCount;
+
+  /// The rating itself.
+  ///
+  /// Caution: This widget doesn't take care of the state itself, so you'll need
+  /// to store the rating for it (just like how `Checkbox`es work).
+  ///
+  /// Example:
+  /// ```dart
+  /// ...
+  /// _MyWidgetState extends State<MyWidget> {
+  ///   double rating = 0;
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     return SmoothStarRating(
+  ///       onRatingChanged: (r) {
+  ///         setState(() {
+  ///           rating = r;
+  ///         });
+  ///       },
+  ///       rating: rating,
+  ///     )
+  ///   }
+  /// }
+  /// ```
   final double rating;
+
+  /// A callback for when the rating is changed.
   final void Function(double rating) onRatingChanged;
+
+  /// The color of the filled and half-filled stars.
   final Color color;
+
+  /// The color of empty stars.
   final Color borderColor;
+
+  /// The size of the stars.
   final double size;
+
+  /// Whether to allow the user to give rate using half stars.
   final bool allowHalfRating;
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -60,6 +60,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.2"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
   quiver:
     dependency: transitive
     description:
@@ -78,7 +85,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.4"
   stack_trace:
     dependency: transitive
     description:
@@ -106,14 +113,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   typed_data:
     dependency: transitive
     description:
@@ -129,4 +136,4 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.0.0 <3.0.0"
+  dart: ">=2.1.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,9 @@
 name: smooth_star_rating
 description: A smooth rating bar
-version: 1.0.2
-author: Thangmam <infimatet@gmail.com>
+version: 1.0.3
+authors:
+- Thangmam <infimatet@gmail.com>
+- Marcel Garus <marcel.garus@gmail.com>
 homepage: https://github.com/thangmam/smoothratingbar.git
 
 environment:
@@ -14,40 +16,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-# For information on the generic Dart part of this file, see the
-# following page: https://www.dartlang.org/tools/pub/pubspec
-
-# The following section is specific to Flutter.
-flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.io/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.io/custom-fonts/#from-packages


### PR DESCRIPTION
Refactored code to be more idiomatic according to the official Effective Dart Style Guide.

Readme:
- Removed constructor documentation and moved it to the code as dartdoc comments. This way, they'll be available in various code editors by hovering over the constructor and they'll also appear in the automatically generated pub documentation of the code.

Core library:
- Reordered constructor, parameters and methods to match the recommended Flutter code style.
- Added various assertions.
- Assertions are now done in the constructor's initializer list instead of a body.
- Discouraged function `typedef` inlined (used only once anyway).
- Removed unnecessary `new` constructor keywords, as recommended since Dart 2.
- Removed unnecessary `double` indication by `.0` as recommended since Dart 2.1 in places where `double`s are obviously expected.
- Simplified second `if` expression from `index > rating - (allowHalfRating ? 0.5 : 1.0) &&
        index < rating` to `allowHalfRating && index > rating - 1`.
- Replaced repeated `if (this.onRatingChanged != null)` checks with a simply dummy function.
- Replaced `.round().toDouble()` with more efficient `.roundToDouble()`.
- Replaced verbose `if (newRating > starCount) {
          newRating = starCount.toDouble();
        }
        if (newRating < 0) {
          newRating = 0.0;
        }` with more idiomatic `.clamp(0.0, starCount.toDouble())`.
- Fixed indentation and code layout in various places using `dartfmt`.

Example:
- minor improvements.

Pubspec:
- Bumped version
- Removed unnecessary comments from `flutter create`
- Added me as an author